### PR TITLE
Vendor strafe helper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/jump/strafe_helper"]
-	path = src/jump/strafe_helper
-	url = https://github.com/kugelrund/strafe_helper.git

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,8 @@
+Does not apply to files in the src/jump/strafe_helper directory,
+which are under the MPL-2.0 license.
+
+See src/jump/strafe_helper/LICENSE
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/NOTE
+++ b/NOTE
@@ -1,0 +1,8 @@
+This project combines code from multiple projects:
+
+Q2pro is licensed under the GPL-2.0 license.
+
+Q2pro-jump is licensed under the GPL-2.0 license. Some of the modifications to q2pro made in this project are adapted from the q2pro-jump project.
+
+strafe_helper is licensed under the MPL-2.0 license. Code from the project and any changes made to it is contained in the src/jump/strafe_helper directory.
+

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ feature as it makes merges not apply cleanly.
 
 ## License
 
-This project is licensed under the GPL-2.0 license. See the LICENSE file for
-details. No warranty is provided and no rights are reserved for the changes
-introduced in this project. You are free to use them in any way you like as
-long as you comply with the upstream q2pro license.
+- Q2pro is licensed under the GPL-2.0 license.
+- Q2pro-jump is licensed under the GPL-2.0 license.
+- strafe_helper is licensed under the MPL-2.0 license.
+
+Any modifications made to the files covered by those licenses follow their original licenses.
+
+No warranty is provided and no additional rights are reserved for the changes
+introduced in this project.

--- a/src/jump/strafe_helper/LICENSE
+++ b/src/jump/strafe_helper/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/src/jump/strafe_helper/README.md
+++ b/src/jump/strafe_helper/README.md
@@ -1,0 +1,36 @@
+# Strafe Helper
+
+Code for drawing a [gazhud](https://www.q3df.org/wiki?p=133)-like HUD overlay
+for id Tech 3 engine games, that shows optimal strafing angles. This was
+initially written for the three **id Tech 3** games by Raven Software,
+*Star Trek: Voyager - Elite Force*, *Star Wars Jedi Knight II: Jedi Outcast* and
+*Star Wars Jedi Knight: Jedi Academy*, but it can work fine for other
+**id Tech 3** games or even other **id Tech** engines too.
+
+## Usage
+
+Include this repository as
+[submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) in your project
+and add `strafe_helper.c` to your build system. Then a header file called
+`strafe_helper_includes.h` has to be created directly outside the submodule.
+It needs to declare the functions `acosf`, `atan2f`, `snprintf`, `sqrtf` and
+`truncf` from the C Standard Library. If the standard library can be used,
+including `math.h` and `stdio.h` is enough. If not (for example for Quake
+Virtual Machine code), equivalent implementations have to be given manually.
+
+Additionally, the functions `shc_drawFilledRectangle` and `shc_drawString` have
+to be implemented as desired, but according to their declarations in
+`strafe_helper_customization.h`.
+
+Then, call the functions `StrafeHelper_SetAccelerationValues` and
+`StrafeHelper_Draw` where appropriate.
+
+If drawing the current speed is not wanted, the declaration of `snprintf` and
+the implementation of `shc_drawString` can be omitted. Instead, use the
+preprocessor definition
+
+```c
+#define STRAFE_HELPER_CUSTOMIZATION_DISABLE_DRAW_SPEED
+```
+
+to disable that part of the strafe helper.

--- a/src/jump/strafe_helper/strafe_helper.c
+++ b/src/jump/strafe_helper/strafe_helper.c
@@ -1,0 +1,179 @@
+#include "strafe_helper.h"
+#include "strafe_helper_customization.h"
+#include "../strafe_helper_includes.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+
+static float sign(const float value)
+{
+	if (value < 0.0f)
+	{
+		return -1.0f;
+	}
+	else if (value > 0.0f)
+	{
+		return 1.0f;
+	}
+	return 0.0f;
+}
+
+static float crossProduct(const float v[2], const float w[2])
+{
+	return v[0] * w[1] - v[1] * w[0];
+}
+
+static float dotProduct(const float v[2], const float w[2])
+{
+	float dot_product = 0.0f;
+	int i;
+	for (i = 0; i < 2; i += 1) {
+		dot_product += v[i] * w[i];
+	}
+	return dot_product;
+}
+
+static float angleBetweenVectors(const float v[2], const float w[2])
+{
+	return atan2f(crossProduct(v, w), dotProduct(v, w));
+}
+
+static float vectorAngleSign(const float v[2], const float w[2])
+{
+	return sign(crossProduct(v, w));
+}
+
+static float vectorNorm(const float v[2])
+{
+	return sqrtf(dotProduct(v, v));
+}
+
+
+/* The current angle between the players velocity vector and forward-looking
+ * vector. */
+static float angle_current;
+/* The angle between the players velocity vector and forward-looking vector
+ * that would have resulted in the maximum amount of acceleration for the
+ * last reported acceleration values. */
+static float angle_optimal;
+/* The (absolute) minimum and maximum angles between the players velocity
+ * vector and forward-looking vector that would give some acceleration. */
+static float angle_minimum;
+static float angle_maximum;
+
+#ifndef STRAFE_HELPER_CUSTOMIZATION_DISABLE_DRAW_SPEED
+/* The current player speed in the horizontal plane */
+static float speed;
+#endif
+
+void StrafeHelper_SetAccelerationValues(const float forward[3],
+                                        const float velocity[3],
+                                        const float wishdir[3],
+                                        const float wishspeed,
+                                        const float accel,
+                                        const float frametime)
+{
+	const float v_z = velocity[2];
+	const float w_z = wishdir[2];
+
+	const float velocity_norm = vectorNorm(velocity);
+	const float wishdir_norm = vectorNorm(wishdir);
+
+	const float forward_velocity_angle = angleBetweenVectors(wishdir, forward);
+	const float angle_sign = vectorAngleSign(wishdir, velocity);
+	const float two_pi = 2.0f * (float)M_PI;
+
+	angle_optimal = (wishspeed * (1.0f - accel * frametime) - v_z * w_z)
+	                / (velocity_norm * wishdir_norm);
+	angle_optimal = acosf(angle_optimal);
+	angle_optimal = angle_sign * angle_optimal - forward_velocity_angle;
+
+	angle_minimum = (wishspeed - v_z * w_z) / (2.0f - wishdir_norm * wishdir_norm)
+	                * wishdir_norm / velocity_norm;
+	angle_minimum = acosf(angle_minimum < 1.0f ? angle_minimum : 1.0f);
+	angle_minimum = angle_sign * angle_minimum - forward_velocity_angle;
+
+	angle_maximum = -0.5f * accel * frametime * wishspeed * wishdir_norm
+	                / velocity_norm;
+	angle_maximum = acosf(angle_maximum);
+	angle_maximum = angle_sign * angle_maximum - forward_velocity_angle;
+
+	angle_current = angleBetweenVectors(forward, velocity);
+
+	/* Make sure that angle_current fits well to the other angles. That is, try
+	 * equivalent angles by adding or subtracting multiples of 2 * M_PI such
+	 * that the angle values are closest to each other. That way we avoid
+	 * differences greater than 2 * M_PI between the angles, which would break
+	 * the drawing code. */
+	angle_current += truncf((angle_minimum - angle_current) / two_pi) * two_pi;
+	angle_current += truncf((angle_maximum - angle_current) / two_pi) * two_pi;
+
+#ifndef STRAFE_HELPER_CUSTOMIZATION_DISABLE_DRAW_SPEED
+	speed = velocity_norm;
+#endif
+}
+
+
+static float angleDiffToPixelDiff(const float angle_difference, const float scale,
+                                  const float hud_width)
+{
+	return angle_difference * (hud_width / 2.0f) * scale / (float)M_PI;
+}
+
+static float angleToPixel(const float angle, const float scale,
+                          const float hud_width)
+{
+	return (hud_width / 2.0f) - 0.5f +
+	       angleDiffToPixelDiff(angle, scale, hud_width);
+}
+
+void StrafeHelper_Draw(const struct StrafeHelperParams *params,
+                       const float hud_width, const float hud_height)
+{
+	float angle_x;
+	float angle_width;
+#ifndef STRAFE_HELPER_CUSTOMIZATION_DISABLE_DRAW_SPEED
+	char speed_string[8];  /* 7 digits should be more than enough for speed */
+#endif
+
+	const float upper_y = (hud_height - params->height) / 2.0f + params->y;
+
+	float offset = 0.0f;
+	if (params->center)	{
+		offset = -angle_current;
+	}
+
+	if (angle_minimum < angle_maximum) {
+		angle_x = angle_minimum + offset;
+		angle_width = angle_maximum - angle_minimum;
+	} else {
+		angle_x = angle_maximum + offset;
+		angle_width = angle_minimum - angle_maximum;
+	}
+
+	shc_drawFilledRectangle(
+		angleToPixel(angle_x, params->scale, hud_width), upper_y,
+		angleDiffToPixelDiff(angle_width, params->scale, hud_width),
+		params->height, shc_ElementId_AcceleratingAngles);
+	shc_drawFilledRectangle(
+		angleToPixel(angle_optimal + offset, params->scale, hud_width) - 0.5f,
+		upper_y, 2.0f, params->height, shc_ElementId_OptimalAngle);
+	if (params->center_marker) {
+		shc_drawFilledRectangle(
+			angleToPixel(angle_current + offset, params->scale, hud_width) - 0.5f,
+			upper_y + params->height / 2.0f, 2.0f, params->height / 2.0f,
+			shc_ElementId_CenterMarker);
+	}
+
+#ifndef STRAFE_HELPER_CUSTOMIZATION_DISABLE_DRAW_SPEED
+	if (params->speed_scale > 0.0f) {
+		snprintf(speed_string, sizeof(speed_string), "%.0f", speed);
+		shc_drawString(
+			hud_width / 2.0f + params->speed_x,
+			upper_y + params->height + params->speed_y,
+			speed_string, params->speed_scale, shc_ElementId_SpeedText);
+	}
+#endif
+}

--- a/src/jump/strafe_helper/strafe_helper.h
+++ b/src/jump/strafe_helper/strafe_helper.h
@@ -1,0 +1,32 @@
+#ifndef STRAFE_HELPER_H
+#define STRAFE_HELPER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct StrafeHelperParams {
+    int center;
+    int center_marker;
+    float scale;
+    float height;
+    float y;
+    float speed_scale;
+    float speed_x;
+    float speed_y;
+};
+
+void StrafeHelper_SetAccelerationValues(const float forward[3],
+                                        const float velocity[3],
+                                        const float wishdir[3],
+                                        const float wishspeed,
+                                        const float accel,
+                                        const float frametime);
+void StrafeHelper_Draw(const struct StrafeHelperParams *params,
+                       const float hud_width, const float hud_height);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* STRAFE_HELPER_H */

--- a/src/jump/strafe_helper/strafe_helper_customization.h
+++ b/src/jump/strafe_helper/strafe_helper_customization.h
@@ -1,0 +1,24 @@
+#ifndef STRAFE_HELPER_CUSTOMIZATION_H
+#define STRAFE_HELPER_CUSTOMIZATION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum shc_ElementId {
+    shc_ElementId_AcceleratingAngles,
+    shc_ElementId_OptimalAngle,
+    shc_ElementId_CenterMarker,
+    shc_ElementId_SpeedText,
+};
+
+void shc_drawFilledRectangle(float x, float y, float w, float h,
+                             enum shc_ElementId element_id);
+void shc_drawString(float x, float y, const char* string, float scale,
+                    enum shc_ElementId element_id);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* STRAFE_HELPER_CUSTOMIZATION_H */


### PR DESCRIPTION
To make modding the strafe helper code, detach the submodule and re-add the code as a regular sub dir.

It is licensed under MPL-2.0 and not GPL-2.0 like q2pro so made a note about it in NOTE and README.