### PR TITLE
Dynamic coloring for hud

### DIFF
--- a/src/jump/strafe_helper/strafe_helper.c
+++ b/src/jump/strafe_helper/strafe_helper.c
@@ -153,10 +153,17 @@ void StrafeHelper_Draw(const struct StrafeHelperParams *params,
 		angle_width = angle_minimum - angle_maximum;
 	}
 
+    // q2jump dynamic strafe_helper
+    // Determine the element ID based on whether the current angle is in the accelerating zone
+    enum shc_ElementId accAnglesElement = 
+        (angle_current >= angle_minimum && angle_current <= angle_maximum)
+        ? shc_ElementId_AcceleratingAnglesInZone
+        : shc_ElementId_AcceleratingAngles;
+
 	shc_drawFilledRectangle(
 		angleToPixel(angle_x, params->scale, hud_width), upper_y,
 		angleDiffToPixelDiff(angle_width, params->scale, hud_width),
-		params->height, shc_ElementId_AcceleratingAngles);
+		params->height, accAnglesElement);
 	shc_drawFilledRectangle(
 		angleToPixel(angle_optimal + offset, params->scale, hud_width) - 0.5f,
 		upper_y, 2.0f, params->height, shc_ElementId_OptimalAngle);

--- a/src/jump/strafe_helper/strafe_helper_customization.h
+++ b/src/jump/strafe_helper/strafe_helper_customization.h
@@ -6,15 +6,16 @@ extern "C" {
 #endif
 
 enum shc_ElementId {
-    shc_ElementId_AcceleratingAngles,
-    shc_ElementId_OptimalAngle,
-    shc_ElementId_CenterMarker,
-    shc_ElementId_SpeedText,
+  shc_ElementId_AcceleratingAngles,
+  shc_ElementId_AcceleratingAnglesInZone,
+  shc_ElementId_OptimalAngle,
+  shc_ElementId_CenterMarker,
+  shc_ElementId_SpeedText,
 };
 
 void shc_drawFilledRectangle(float x, float y, float w, float h,
                              enum shc_ElementId element_id);
-void shc_drawString(float x, float y, const char* string, float scale,
+void shc_drawString(float x, float y, const char *string, float scale,
                     enum shc_ElementId element_id);
 
 #ifdef __cplusplus

--- a/src/jump/strafe_helper_includes.h
+++ b/src/jump/strafe_helper_includes.h
@@ -15,8 +15,10 @@
 
 static inline uint32_t getColor(int element_id) {
   switch (element_id) {
-  case shc_ElementId_AcceleratingAngles:
+  case shc_ElementId_AcceleratingAnglesInZone:
     return MakeColor(0, 128, 32, 96); // shi_color_accelerating
+  case shc_ElementId_AcceleratingAngles:
+      return MakeColor(128, 0, 32, 96); // shi_color_accelerating not in zone
   case shc_ElementId_OptimalAngle:
     return MakeColor(0, 255, 64, 192); // shi_color_optimal
   case shc_ElementId_CenterMarker:


### PR DESCRIPTION
The accelerating zones are drawn in red when the current angle is not inside them.

Not configurable yet.
